### PR TITLE
Updated Evergreen keywords.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <div id="container">
       <h1>Magic the Gathering: Mechanics Storm Scale Chart</h1>
       <p>Adapted from <a href="http://i.imgur.com/S3GZDPi.jpg">this image</a> created by <a href="http://www.reddit.com/user/justhereforhides">justhereforhides</a>.</p>
-      <p>Those of you who read <a href="http://markrosewater.tumblr.com/">Mark Rosewater's blog</a> probably know the Storm Scale. If you don't, you should start reading it. It's pretty good. Anyway, the Storm Scale rates Maro's subjective estimation of how likely it is for a certain mechanic/theme/card to be (re-)printed in an expert expansion on a scale from 1 to 10:</p>
+      <p>Those of you who read <a href="http://markrosewater.tumblr.com/">Mark Rosewater's blog</a> probably know the <a href="http://magic.wizards.com/en/articles/archive/making-magic/storm-scale-khans-tarkir-block-2016-02-29">Storm Scale</a>. If you don't, you should start reading it. It's pretty good. Anyway, the Storm Scale rates Maro's subjective estimation of how likely it is for a certain mechanic/theme/card to be (re-)printed in an expert expansion on a scale from 1 to 10:</p>
       <ol class="scale" start="0">
         
         <li class="rating-0"><span>Evergreen<span></li>
@@ -49,7 +49,7 @@
           
           <tr>
             <td class="effect">Evergreen</td>
-            <td class="rule">Deathtouch, Defender, Double Strike, Enchant, Equip, Fight, First Strike, Flask, Flying, Haste, Hexproof, Indestructible, Intimidate, Landwalk, Lifelink, Protection, Reach, Regeneration, Trample, Vigilance.</td>
+            <td class="rule">Deathtouch, Defender, Double Strike, Enchant, Equip, Fight, First Strike, Flash, Flying, Haste, Hexproof, Indestructible, Lifelink, Menace, Prowess, Reach, Regeneration, Scry, Trample, Vigilance.</td>
             <td class="blocks">All</br></td>
             <td class="card"><a href="http://magiccards.info/scans/en/10e/268.jpg"><img src="http://magiccards.info/scans/en/10e/268.jpg" /></a></td>
             <td class="rating rating-0">0</td>
@@ -120,6 +120,14 @@
           </tr>
           
           <tr>
+            <td class="effect">Protection</td>
+            <td class="rule">This can&#39;t be blocked, targeted, dealt damage, or enchanted by anything (quality)</td>
+            <td class="blocks">Formerly Evergreen</br></td>
+            <td class="card"><a href=""><img src="" /></a></td>
+            <td class="rating rating-2">2</td>
+          </tr>
+          
+          <tr>
             <td class="effect">Unearth</td>
             <td class="rule">[Cost]: Return this card from your graveyward to the battliefield. It gans haste. Exile it at the beginning of the next end step or if it would leave the battlefield. Unearth only as a sorcery.</td>
             <td class="blocks">Alara</br></td>
@@ -180,6 +188,14 @@
             <td class="rule">Colored mana costs that can alternatively be paid with {2}.</td>
             <td class="blocks">Shadowmoor</br></td>
             <td class="card"><a href="http://magiccards.info/scans/en/ddk/26.jpg"><img src="http://magiccards.info/scans/en/ddk/26.jpg" /></a></td>
+            <td class="rating rating-3">3</td>
+          </tr>
+          
+          <tr>
+            <td class="effect">Landwalk</td>
+            <td class="rule">This creature can&#39;t be blocked as long as defending player controls a relevant land</td>
+            <td class="blocks">Formerly Evergreen</br></td>
+            <td class="card"><a href=""><img src="" /></a></td>
             <td class="rating rating-3">3</td>
           </tr>
           
@@ -363,6 +379,22 @@
             <td class="effect">Devour</td>
             <td class="rule">As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many &#43;1/&#43;1 counters on it.</td>
             <td class="blocks"></td>
+            <td class="card"><a href=""><img src="" /></a></td>
+            <td class="rating rating-7">7</td>
+          </tr>
+          
+          <tr>
+            <td class="effect">Fear</td>
+            <td class="rule">This creature can&#39;t be blocked except by artifact creatures and/or black creatures.</td>
+            <td class="blocks">Formerly Evergreen</br></td>
+            <td class="card"><a href=""><img src="" /></a></td>
+            <td class="rating rating-7">7</td>
+          </tr>
+          
+          <tr>
+            <td class="effect">Intimidate</td>
+            <td class="rule">This creature can&#39;t be blocked except by artifact creatures and/or creatures that share a color with it</td>
+            <td class="blocks">Formerly Evergreen</br></td>
             <td class="card"><a href=""><img src="" /></a></td>
             <td class="rating rating-7">7</td>
           </tr>

--- a/mechanics.json
+++ b/mechanics.json
@@ -6,7 +6,7 @@
         "effect": "Evergreen",
         "example": "http://magiccards.info/scans/en/10e/268.jpg",
         "rating": 0,
-        "rule": "Deathtouch, Defender, Double Strike, Enchant, Equip, Fight, First Strike, Flask, Flying, Haste, Hexproof, Indestructible, Intimidate, Landwalk, Lifelink, Protection, Reach, Regeneration, Trample, Vigilance."
+        "rule": "Deathtouch, Defender, Double Strike, Enchant, Equip, Fight, First Strike, Flash, Flying, Haste, Hexproof, Indestructible, Lifelink, Menace, Prowess, Reach, Regeneration, Scry, Trample, Vigilance."
     },
     {
         "blocks": [
@@ -90,6 +90,13 @@
         "rating": 2,
         "rule": "You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there."
     },
+	{
+        "blocks": ["Formerly Evergreen"],
+        "effect": "Protection",
+        "example": "",
+        "rating": 2,
+        "rule": "This can't be blocked, targeted, dealt damage, or enchanted by anything (quality)"
+    },
     {
         "blocks": [
             "Alara"
@@ -162,6 +169,13 @@
         "example": "http://magiccards.info/scans/en/ddk/26.jpg",
         "rating": 3,
         "rule": "Colored mana costs that can alternatively be paid with {2}."
+    },
+    {
+        "blocks": ["Formerly Evergreen"],
+        "effect": "Landwalk",
+        "example": "",
+        "rating": 3,
+        "rule": "This creature can't be blocked as long as defending player controls a relevant land"
     },
     {
         "blocks": [
@@ -330,6 +344,20 @@
         "example": "",
         "rating": 7,
         "rule": "As this enters the battlefield, you may sacrifice any number of creatures. This creature enters the battlefield with that many +1/+1 counters on it."
+    },
+	{
+        "blocks": ["Formerly Evergreen"],
+        "effect": "Fear",
+        "example": "",
+        "rating": 7,
+        "rule": "This creature can't be blocked except by artifact creatures and/or black creatures."
+    },
+	{
+        "blocks": ["Formerly Evergreen"],
+        "effect": "Intimidate",
+        "example": "",
+        "rating": 7,
+        "rule": "This creature can't be blocked except by artifact creatures and/or creatures that share a color with it"
     },
     {
         "blocks": [],

--- a/template.html
+++ b/template.html
@@ -9,7 +9,7 @@
     <div id="container">
       <h1>Magic the Gathering: Mechanics Storm Scale Chart</h1>
       <p>Adapted from <a href="http://i.imgur.com/S3GZDPi.jpg">this image</a> created by <a href="http://www.reddit.com/user/justhereforhides">justhereforhides</a>.</p>
-      <p>Those of you who read <a href="http://markrosewater.tumblr.com/">Mark Rosewater's blog</a> probably know the Storm Scale. If you don't, you should start reading it. It's pretty good. Anyway, the Storm Scale rates Maro's subjective estimation of how likely it is for a certain mechanic/theme/card to be (re-)printed in an expert expansion on a scale from 1 to 10:</p>
+      <p>Those of you who read <a href="http://markrosewater.tumblr.com/">Mark Rosewater's blog</a> probably know the <a href="http://magic.wizards.com/en/articles/archive/making-magic/storm-scale-khans-tarkir-block-2016-02-29">Storm Scale</a>. If you don't, you should start reading it. It's pretty good. Anyway, the Storm Scale rates Maro's subjective estimation of how likely it is for a certain mechanic/theme/card to be (re-)printed in an expert expansion on a scale from 1 to 10:</p>
       <ol class="scale" start="0">
         {{range $index, $element := .Scale }}
         <li class="rating-{{$index}}"><span>{{$element}}<span></li>


### PR DESCRIPTION
I made a few minor changes to bring it up to date with the the post-Origins Evergreen mechanics:

Depreciated Intimidate and Landwalk in preference with Menace.
Moved Protection from Evergreen to a 2.
Added Prowess and Scry.

I also fixed a typo where "Flash" was spelled as "Flask".
